### PR TITLE
Treat warnings as errors

### DIFF
--- a/Installer.cpp
+++ b/Installer.cpp
@@ -245,6 +245,8 @@ HRESULT ResetAclPermissionsOnApplicationFolder()
 
     // Reset the ACL of the folder where Notepad++ is installed.
     aclHelper.ResetAcl(applicationPath);
+
+    return S_OK;
 }
 
 HRESULT NppShell::Installer::RegisterSparsePackage()

--- a/Installer.cpp
+++ b/Installer.cpp
@@ -348,6 +348,17 @@ HRESULT NppShell::Installer::Install()
 
     UnregisterOldContextMenu();
 
+    // Ensure we have removed any old files that might be left behind.
+    MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_01.dll");
+    MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_02.dll");
+    MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_03.dll");
+    MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_04.dll");
+    MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_05.dll");
+    MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_06.dll");
+
+    // Since we have unregistered the old context menu, we refresh the shell, just to be sure.
+    SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, 0, 0);
+
     if (isWindows11)
     {
         UnregisterSparsePackage();

--- a/NppShell.vcxproj
+++ b/NppShell.vcxproj
@@ -126,6 +126,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -148,6 +149,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -167,6 +169,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -191,6 +194,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -217,6 +221,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -241,6 +246,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OutputFile>$(OutDir)$(TargetName).arm64$(TargetExt)</OutputFile>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Like I mentioned in #3, this turns on "Treat warnings as errors", which we should be using, to ensure warnings are taken care of.