### PR TITLE
Added ReloadExplorer exported function

### DIFF
--- a/Installer.cpp
+++ b/Installer.cpp
@@ -413,3 +413,30 @@ STDAPI CleanupDll()
 
     return MoveFileToTempAndScheduleDeletion(currentFilePath);
 }
+
+STDAPI ReloadExplorer()
+{
+    // First we locate the correct Explorer process, based on the "Shell_TrayWnd" window class.
+    HWND hwnd = FindWindowW(L"Shell_TrayWnd", NULL);
+    
+    // Then we find the process id of the process owning that window (which is the correct Explorer instance).
+    DWORD pid(0);
+    GetWindowThreadProcessId(hwnd, &pid);
+
+    if (!pid)
+    {
+        return ERROR_FILE_NOT_FOUND;
+    }
+
+    // Now we have the pid of the process, we can open it.
+    HANDLE hExplorer = OpenProcess(PROCESS_TERMINATE, false, pid);
+
+    // Then we just restart the process.
+    // Passing 2 as the 2nd parameter tells Explorer to restart automatically.
+    TerminateProcess(hExplorer, 2);
+
+    // Finally we cleanup by closing the handle.
+    CloseHandle(hExplorer);
+
+    return S_OK;
+}

--- a/Installer.h
+++ b/Installer.h
@@ -14,3 +14,4 @@ namespace NppShell::Installer
 }
 
 STDAPI CleanupDll();
+STDAPI ReloadExplorer();

--- a/source.def
+++ b/source.def
@@ -6,3 +6,4 @@ DllGetClassObject          PRIVATE
 DllRegisterServer          PRIVATE
 DllUnregisterServer        PRIVATE
 CleanupDll                 PRIVATE
+ReloadExplorer             PRIVATE


### PR DESCRIPTION
The implements the needed functionality to restart the explorer.exe process while installing.
This will not cause any dataloss, since all programs keeps running.

This, along with a small change to NSIS installer will fix the issue with missing context menus when the old version is being updated.
This is a one time thing, going from 8.5.1 and below to 8.5.2 and above.
Going from 8.5.2 to a later version won't require this to run, so it is a one time thing.