### PR TITLE
Fix the context menu needs restarting explorer to appear issue under Win 8/10

### DIFF
--- a/Installer.cpp
+++ b/Installer.cpp
@@ -351,14 +351,12 @@ HRESULT NppShell::Installer::Install()
     UnregisterOldContextMenu();
 
     // Ensure we have removed any old files that might be left behind.
-
     MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_01.dll");
     MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_02.dll");
     MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_03.dll");
     MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_04.dll");
     MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_05.dll");
     MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_06.dll");
-
 
     // Since we have unregistered the old context menu, we refresh the shell, just to be sure.
     SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, 0, 0);

--- a/Installer.cpp
+++ b/Installer.cpp
@@ -344,9 +344,14 @@ HRESULT NppShell::Installer::Install()
 
     HRESULT result;
 
+    // Clean up the 8.5 Windows 11 hack if present.
+    CleanupHack();
+
+    /*
     UnregisterOldContextMenu();
 
     // Ensure we have removed any old files that might be left behind.
+
     MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_01.dll");
     MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_02.dll");
     MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_03.dll");
@@ -354,9 +359,10 @@ HRESULT NppShell::Installer::Install()
     MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_05.dll");
     MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_06.dll");
 
+
     // Since we have unregistered the old context menu, we refresh the shell, just to be sure.
     SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, 0, 0);
-
+    */
     if (isWindows11)
     {
         UnregisterSparsePackage();


### PR DESCRIPTION
Fix the context menu needs restarting explorer to appear issue after updating from the old NppShell_06.dll to new NppShell.dll.
 
The fix is to not unregister the old one so the old context menu still working until user restarting explorer or windows, then the old context menu disappears and the new one appears.

Fix #13