### PR TITLE
Implement handling of both new and old install method at the same time

### DIFF
--- a/BaseNppExplorerCommandHandler.cpp
+++ b/BaseNppExplorerCommandHandler.cpp
@@ -1,12 +1,17 @@
 #include "pch.h"
-#include "EditWithNppExplorerCommandHandler.h"
+#include "BaseNppExplorerCommandHandler.h"
 
 #include "PathHelper.h"
 
 using namespace NppShell::CommandHandlers;
 using namespace NppShell::Helpers;
 
-const wstring EditWithNppExplorerCommandHandler::GetNppExecutableFullPath()
+BaseNppExplorerCommandHandler::BaseNppExplorerCommandHandler()
+{
+    counter = make_unique<SharedCounter>();
+}
+
+const wstring BaseNppExplorerCommandHandler::GetNppExecutableFullPath()
 {
     const wstring path = GetApplicationPath();
     const wstring fileName = L"\\notepad++.exe";
@@ -14,19 +19,19 @@ const wstring EditWithNppExplorerCommandHandler::GetNppExecutableFullPath()
     return path + fileName;
 }
 
-const wstring EditWithNppExplorerCommandHandler::Title()
+const wstring BaseNppExplorerCommandHandler::Title()
 {
     return L"Edit with Notepad++";
 }
 
-const wstring EditWithNppExplorerCommandHandler::Icon()
+const wstring BaseNppExplorerCommandHandler::Icon()
 {
     const wstring fileName = GetNppExecutableFullPath();
 
     return fileName;
 }
 
-const wstring EditWithNppExplorerCommandHandler::GetCommandLine(const wstring& itemName)
+const wstring BaseNppExplorerCommandHandler::GetCommandLine(const wstring& itemName)
 {
     const wstring fileName = GetNppExecutableFullPath();
     const wstring parameters = L"\"" + itemName + L"\"";
@@ -34,7 +39,7 @@ const wstring EditWithNppExplorerCommandHandler::GetCommandLine(const wstring& i
     return L"\"" + fileName + L"\" " + parameters;
 }
 
-IFACEMETHODIMP EditWithNppExplorerCommandHandler::Invoke(IShellItemArray* psiItemArray, IBindCtx* pbc) noexcept try
+IFACEMETHODIMP BaseNppExplorerCommandHandler::Invoke(IShellItemArray* psiItemArray, IBindCtx* pbc) noexcept try
 {
     UNREFERENCED_PARAMETER(pbc);
 
@@ -88,3 +93,10 @@ IFACEMETHODIMP EditWithNppExplorerCommandHandler::Invoke(IShellItemArray* psiIte
     return S_OK;
 }
 CATCH_RETURN();
+
+const EXPCMDSTATE BaseNppExplorerCommandHandler::State(IShellItemArray* psiItemArray)
+{
+    UNREFERENCED_PARAMETER(psiItemArray);
+
+    throw L"State must be overridden in all implementations";
+}

--- a/BaseNppExplorerCommandHandler.h
+++ b/BaseNppExplorerCommandHandler.h
@@ -1,24 +1,28 @@
 #pragma once
-#include "pch.h"
-
 #include "ExplorerCommandBase.h"
+#include "SharedCounter.h"
+
+using namespace NppShell::Helpers;
 
 namespace NppShell::CommandHandlers
 {
-#ifdef WIN64
-    class __declspec(uuid("B298D29A-A6ED-11DE-BA8C-A68E55D89593")) EditWithNppExplorerCommandHandler : public ExplorerCommandBase
-#else
-    class __declspec(uuid("00F3C2EC-A6EE-11DE-A03A-EF8F55D89593")) EditWithNppExplorerCommandHandler : public ExplorerCommandBase
-#endif
+    class BaseNppExplorerCommandHandler : public ExplorerCommandBase
     {
     public:
+        BaseNppExplorerCommandHandler();
+
         const wstring Title() override;
         const wstring Icon() override;
 
         IFACEMETHODIMP Invoke(IShellItemArray* psiItemArray, IBindCtx* pbc) noexcept override;
 
+        virtual const EXPCMDSTATE State(IShellItemArray* psiItemArray) override;
+
     private:
         const wstring GetNppExecutableFullPath();
         const wstring GetCommandLine(const wstring& itemName);
+
+    protected:
+        unique_ptr<SharedCounter> counter;
     };
 }

--- a/ClassicEditWithNppExplorerCommandHandler.cpp
+++ b/ClassicEditWithNppExplorerCommandHandler.cpp
@@ -1,0 +1,19 @@
+#include "pch.h"
+#include "ClassicEditWithNppExplorerCommandHandler.h"
+
+using namespace NppShell::CommandHandlers;
+
+const EXPCMDSTATE ClassicEditWithNppExplorerCommandHandler::State(IShellItemArray* psiItemArray)
+{
+    UNREFERENCED_PARAMETER(psiItemArray);
+
+    int state = counter->GetValue();
+
+    if (state == 3 || state == 5)
+    {
+        // This is on Windows 11, with both the modern and classic being shows, so we hide this one.
+        return ECS_HIDDEN;
+    }
+
+    return ECS_ENABLED;
+}

--- a/ClassicEditWithNppExplorerCommandHandler.h
+++ b/ClassicEditWithNppExplorerCommandHandler.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "BaseNppExplorerCommandHandler.h"
+
+using namespace NppShell::Helpers;
+
+namespace NppShell::CommandHandlers
+{
+#ifdef WIN64
+    class __declspec(uuid("B298D29A-A6ED-11DE-BA8C-A68E55D89593")) ClassicEditWithNppExplorerCommandHandler : public BaseNppExplorerCommandHandler
+#else
+    class __declspec(uuid("00F3C2EC-A6EE-11DE-A03A-EF8F55D89593")) ClassicEditWithNppExplorerCommandHandler : public BaseNppExplorerCommandHandler
+#endif
+    {
+    public:
+        const EXPCMDSTATE State(IShellItemArray* psiItemArray);
+    };
+}

--- a/ExplorerCommandBase.cpp
+++ b/ExplorerCommandBase.cpp
@@ -8,13 +8,6 @@ const EXPCMDFLAGS ExplorerCommandBase::Flags()
     return ECF_DEFAULT;
 }
 
-const EXPCMDSTATE ExplorerCommandBase::State(IShellItemArray* psiItemArray)
-{
-    UNREFERENCED_PARAMETER(psiItemArray);
-
-    return ECS_ENABLED;
-}
-
 IFACEMETHODIMP ExplorerCommandBase::GetTitle(IShellItemArray* psiItemArray, LPWSTR* ppszName)
 {
     UNREFERENCED_PARAMETER(psiItemArray);
@@ -57,7 +50,8 @@ IFACEMETHODIMP ExplorerCommandBase::GetFlags(EXPCMDFLAGS* flags)
     return S_OK;
 }
 
-IFACEMETHODIMP ExplorerCommandBase::GetCanonicalName(GUID* pguidCommandName) {
+IFACEMETHODIMP ExplorerCommandBase::GetCanonicalName(GUID* pguidCommandName)
+{
     *pguidCommandName = GUID_NULL;
     return S_OK;
 }

--- a/ExplorerCommandBase.h
+++ b/ExplorerCommandBase.h
@@ -9,7 +9,7 @@ namespace NppShell::CommandHandlers
         virtual const wstring Title() = 0;
         virtual const wstring Icon() = 0;
         virtual const EXPCMDFLAGS Flags();
-        virtual const EXPCMDSTATE State(IShellItemArray* psiItemArray);
+        virtual const EXPCMDSTATE State(IShellItemArray* psiItemArray) = 0;
 
         IFACEMETHODIMP GetTitle(IShellItemArray* psiItemArray, LPWSTR* ppszName);
         IFACEMETHODIMP GetIcon(IShellItemArray* psiItemArray, LPWSTR* ppszIcon);

--- a/Installer.cpp
+++ b/Installer.cpp
@@ -1,7 +1,7 @@
 #include "pch.h"
 #include "Installer.h"
 
-#include "EditWithNppExplorerCommandHandler.h"
+#include "ClassicEditWithNppExplorerCommandHandler.h"
 #include "PathHelper.h"
 #include "AclHelper.h"
 
@@ -65,7 +65,7 @@ bool IsWindows11Installation()
 
 wstring GetCLSIDString()
 {
-    const auto uuid = __uuidof(NppShell::CommandHandlers::EditWithNppExplorerCommandHandler);
+    const auto uuid = __uuidof(NppShell::CommandHandlers::ClassicEditWithNppExplorerCommandHandler);
 
     LPOLESTR guidString = 0;
     const HRESULT result = StringFromCLSID(uuid, &guidString);
@@ -360,10 +360,8 @@ HRESULT NppShell::Installer::Install()
 
         result = RegisterSparsePackage();
     }
-    else
-    {
-        result = RegisterOldContextMenu();
-    }
+
+    result = RegisterOldContextMenu();
 
     // Ensure we schedule old files for removal on next reboot.
     MoveFileToTempAndScheduleDeletion(GetApplicationPath() + L"\\NppShell_01.dll", false);

--- a/ModernEditWithNppExplorerCommandHandler.cpp
+++ b/ModernEditWithNppExplorerCommandHandler.cpp
@@ -1,0 +1,11 @@
+#include "pch.h"
+#include "ModernEditWithNppExplorerCommandHandler.h"
+
+using namespace NppShell::CommandHandlers;
+
+const EXPCMDSTATE ModernEditWithNppExplorerCommandHandler::State(IShellItemArray* psiItemArray)
+{
+    UNREFERENCED_PARAMETER(psiItemArray);
+
+    return ECS_ENABLED;
+}

--- a/ModernEditWithNppExplorerCommandHandler.h
+++ b/ModernEditWithNppExplorerCommandHandler.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "BaseNppExplorerCommandHandler.h"
+
+using namespace NppShell::Helpers;
+
+namespace NppShell::CommandHandlers
+{
+    class __declspec(uuid("E6950302-61F0-4FEB-97DB-855E30D4A991")) ModernEditWithNppExplorerCommandHandler : public BaseNppExplorerCommandHandler
+    {
+    public:
+        const EXPCMDSTATE State(IShellItemArray* psiItemArray);
+    };
+}

--- a/NppShell.vcxproj
+++ b/NppShell.vcxproj
@@ -263,19 +263,24 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="AclHelper.h" />
-    <ClInclude Include="EditWithNppExplorerCommandHandler.h" />
+    <ClInclude Include="BaseNppExplorerCommandHandler.h" />
+    <ClInclude Include="ClassicEditWithNppExplorerCommandHandler.h" />
     <ClInclude Include="ExplorerCommandBase.h" />
     <ClInclude Include="framework.h" />
+    <ClInclude Include="ModernEditWithNppExplorerCommandHandler.h" />
     <ClInclude Include="PathHelper.h" />
     <ClInclude Include="Installer.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="SharedCounter.h" />
     <ClInclude Include="SimpleFactory.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AclHelper.cpp" />
+    <ClCompile Include="BaseNppExplorerCommandHandler.cpp" />
+    <ClCompile Include="ClassicEditWithNppExplorerCommandHandler.cpp" />
     <ClCompile Include="dllmain.cpp" />
-    <ClCompile Include="EditWithNppExplorerCommandHandler.cpp" />
     <ClCompile Include="ExplorerCommandBase.cpp" />
+    <ClCompile Include="ModernEditWithNppExplorerCommandHandler.cpp" />
     <ClCompile Include="PathHelper.cpp" />
     <ClCompile Include="Installer.cpp" />
     <ClCompile Include="pch.cpp">
@@ -286,6 +291,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="SharedCounter.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/NppShell.vcxproj.filters
+++ b/NppShell.vcxproj.filters
@@ -13,14 +13,14 @@
     <Filter Include="Helpers">
       <UniqueIdentifier>{9c186a78-bd74-4ac7-b560-e61aeb6d2350}</UniqueIdentifier>
     </Filter>
+    <Filter Include="CommandHandlers\Base">
+      <UniqueIdentifier>{7a045eaf-b500-484e-998a-394c98da10f1}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="CommandHandlers\Implementation">
+      <UniqueIdentifier>{fc167318-0574-47ba-aa80-a48008ef4b8c}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="EditWithNppExplorerCommandHandler.h">
-      <Filter>CommandHandlers</Filter>
-    </ClInclude>
-    <ClInclude Include="ExplorerCommandBase.h">
-      <Filter>CommandHandlers</Filter>
-    </ClInclude>
     <ClInclude Include="Installer.h">
       <Filter>Installer</Filter>
     </ClInclude>
@@ -35,14 +35,21 @@
     <ClInclude Include="AclHelper.h">
       <Filter>Helpers</Filter>
     </ClInclude>
+    <ClInclude Include="SharedCounter.h" />
+    <ClInclude Include="ExplorerCommandBase.h">
+      <Filter>CommandHandlers\Base</Filter>
+    </ClInclude>
+    <ClInclude Include="BaseNppExplorerCommandHandler.h">
+      <Filter>CommandHandlers\Base</Filter>
+    </ClInclude>
+    <ClInclude Include="ClassicEditWithNppExplorerCommandHandler.h">
+      <Filter>CommandHandlers\Implementation</Filter>
+    </ClInclude>
+    <ClInclude Include="ModernEditWithNppExplorerCommandHandler.h">
+      <Filter>CommandHandlers\Implementation</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="EditWithNppExplorerCommandHandler.cpp">
-      <Filter>CommandHandlers</Filter>
-    </ClCompile>
-    <ClCompile Include="ExplorerCommandBase.cpp">
-      <Filter>CommandHandlers</Filter>
-    </ClCompile>
     <ClCompile Include="Installer.cpp">
       <Filter>Installer</Filter>
     </ClCompile>
@@ -53,6 +60,19 @@
     </ClCompile>
     <ClCompile Include="AclHelper.cpp">
       <Filter>Helpers</Filter>
+    </ClCompile>
+    <ClCompile Include="SharedCounter.cpp" />
+    <ClCompile Include="ExplorerCommandBase.cpp">
+      <Filter>CommandHandlers\Base</Filter>
+    </ClCompile>
+    <ClCompile Include="BaseNppExplorerCommandHandler.cpp">
+      <Filter>CommandHandlers\Base</Filter>
+    </ClCompile>
+    <ClCompile Include="ClassicEditWithNppExplorerCommandHandler.cpp">
+      <Filter>CommandHandlers\Implementation</Filter>
+    </ClCompile>
+    <ClCompile Include="ModernEditWithNppExplorerCommandHandler.cpp">
+      <Filter>CommandHandlers\Implementation</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/Packaging/AppxManifest.xml
+++ b/Packaging/AppxManifest.xml
@@ -33,14 +33,14 @@
         <desktop4:Extension Category="windows.fileExplorerContextMenus">
           <desktop4:FileExplorerContextMenus>
             <desktop5:ItemType Type="*">
-              <desktop5:Verb Id="EditWithNotepadPlusPlus" Clsid="B298D29A-A6ED-11DE-BA8C-A68E55D89593" />
+              <desktop5:Verb Id="EditWithNotepadPlusPlus" Clsid="E6950302-61F0-4FEB-97DB-855E30D4A991" />
             </desktop5:ItemType>
           </desktop4:FileExplorerContextMenus>
         </desktop4:Extension>
         <com:Extension Category="windows.comServer">
           <com:ComServer>
             <com:SurrogateServer DisplayName="Notepad++ Shell Extension">
-              <com:Class Id="B298D29A-A6ED-11DE-BA8C-A68E55D89593" Path="NppShell.dll" ThreadingModel="STA"/>
+              <com:Class Id="E6950302-61F0-4FEB-97DB-855E30D4A991" Path="NppShell.dll" ThreadingModel="STA"/>
             </com:SurrogateServer>
           </com:ComServer>
         </com:Extension>

--- a/SharedCounter.cpp
+++ b/SharedCounter.cpp
@@ -1,0 +1,58 @@
+#include "pch.h"
+#include "SharedCounter.h"
+
+using namespace NppShell::Helpers;
+
+SharedCounter::SharedCounter()
+{
+    // Create or open the shared memory mapped file
+    hFileMapping = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, sizeof(int), L"Local\\BaseNppExplorerCommandHandlerSharedMemory");
+    if (hFileMapping == NULL)
+    {
+        MessageBox(NULL, L"Failed to create or open shared memory mapped file", L"SharedCounter", MB_OK | MB_ICONERROR);
+        return;
+    }
+
+    // Create a mutex to synchronize access to the shared memory
+    hMutex = CreateMutex(NULL, FALSE, L"Local\\BaseNppExplorerCommandHandlerSharedMutex");
+    if (hMutex == NULL)
+    {
+        MessageBox(NULL, L"Failed to create mutex", L"SharedCounter", MB_OK | MB_ICONERROR);
+        CloseHandle(hFileMapping);
+        return;
+    }
+
+    // Map the shared memory into the current process's address space
+    pCounter = (int*)MapViewOfFile(hFileMapping, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(int));
+    if (pCounter == NULL)
+    {
+        MessageBox(NULL, L"Failed to map shared memory", L"SharedCounter", MB_OK | MB_ICONERROR);
+        CloseHandle(hMutex);
+        CloseHandle(hFileMapping);
+        return;
+    }
+
+    // Increment the shared counter
+    WaitForSingleObject(hMutex, INFINITE);
+    *pCounter += 1;
+    localValue = *pCounter;
+    ReleaseMutex(hMutex);
+}
+
+SharedCounter::~SharedCounter() {
+    // Decrement the shared counter
+    WaitForSingleObject(hMutex, INFINITE);
+    *pCounter -= 1;
+    ReleaseMutex(hMutex);
+
+    // Unmap the shared memory from the current process's address space
+    UnmapViewOfFile(pCounter);
+
+    // Close the mutex and the shared memory mapped file
+    CloseHandle(hMutex);
+    CloseHandle(hFileMapping);
+}
+
+int SharedCounter::GetValue() const {
+    return localValue;
+}

--- a/SharedCounter.h
+++ b/SharedCounter.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace NppShell::Helpers
+{
+    class SharedCounter {
+    public:
+        SharedCounter();
+        ~SharedCounter();
+
+        int GetValue() const;
+
+    private:
+        HANDLE hFileMapping;
+        HANDLE hMutex;
+        int* pCounter;
+        int localValue;
+    };
+}

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -2,7 +2,8 @@
 
 #include "Installer.h"
 #include "SimpleFactory.h"
-#include "EditWithNppExplorerCommandHandler.h"
+#include "ClassicEditWithNppExplorerCommandHandler.h"
+#include "ModernEditWithNppExplorerCommandHandler.h"
 
 using namespace NppShell::CommandHandlers;
 using namespace NppShell::Factories;
@@ -54,9 +55,13 @@ _Use_decl_annotations_ STDAPI DllGetClassObject(REFCLSID rclsid, REFIID riid, LP
 {
     *ppv = nullptr;
 
-    if (rclsid == __uuidof(EditWithNppExplorerCommandHandler))
+    if (rclsid == __uuidof(ClassicEditWithNppExplorerCommandHandler))
     {
-        return winrt::make<SimpleFactory<EditWithNppExplorerCommandHandler>>().as(riid, ppv);
+        return winrt::make<SimpleFactory<ClassicEditWithNppExplorerCommandHandler>>().as(riid, ppv);
+    }
+    else if (rclsid == __uuidof(ModernEditWithNppExplorerCommandHandler))
+    {
+        return winrt::make<SimpleFactory<ModernEditWithNppExplorerCommandHandler>>().as(riid, ppv);
     }
     else
     {


### PR DESCRIPTION
This PR does the following:

- Creates two versions of the command handler (both inherits a base class where the implementation is).
- Uses a memory mapped file along with a mutex to communicate between the two, to have a shared counter.
- The counter value is used inside the classic version of the handler to determine if it should be shown or not.

By doing this, we can register both the new MSIX and the old registry on Windows 11, and ensure the following:
- If the MSIX registered entry is shown inside the classic menu, the old registry based one hides itself.
- If for some reason the MSIX registered entry doesn't show up inside the classic menu, the old registry based on shows itself.

From a users point of view - it "just works", and they always only see one entry in the old menu.

* This fixes notepad-plus-plus/notepad-plus-plus#13399