### PR TITLE
Handle systems with multiple users

### DIFF
--- a/Installer.h
+++ b/Installer.h
@@ -11,6 +11,8 @@ namespace NppShell::Installer
 
     HRESULT Install();
     HRESULT Uninstall();
+
+    void EnsureRegistrationOnCurrentUser();
 }
 
 STDAPI CleanupDll();

--- a/PathHelper.cpp
+++ b/PathHelper.cpp
@@ -30,3 +30,15 @@ const wstring NppShell::Helpers::GetContextMenuFullName()
     path modulePath = GetThisModulePath();
     return modulePath.wstring();
 }
+
+const wstring NppShell::Helpers::GetExecutingModuleName()
+{
+    wchar_t pathBuffer[FILENAME_MAX] = { 0 };
+    GetModuleFileNameW(NULL, pathBuffer, FILENAME_MAX);
+    PathStripPathW(pathBuffer);
+
+    wstring moduleName(pathBuffer);
+    transform(moduleName.begin(), moduleName.end(), moduleName.begin(), towlower);
+
+    return moduleName;
+}

--- a/PathHelper.h
+++ b/PathHelper.h
@@ -8,4 +8,5 @@ namespace NppShell::Helpers
     const wstring GetApplicationPath();
     const wstring GetContextMenuPath();
     const wstring GetContextMenuFullName();
+    const wstring GetExecutingModuleName();
 }

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -9,6 +9,7 @@ using namespace NppShell::CommandHandlers;
 using namespace NppShell::Factories;
 
 HMODULE thisModule;
+thread ensureRegistrationThread;
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
 {
@@ -18,6 +19,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
     {
         case DLL_PROCESS_ATTACH:
             thisModule = hModule;
+            NppShell::Installer::EnsureRegistrationOnCurrentUser();
             break;
         case DLL_THREAD_ATTACH:
         case DLL_THREAD_DETACH:


### PR DESCRIPTION
This handles multi user systems.
Since we cannot install a sparse package (msix) for all users on the system (due to the way the store and it's services are architected), we have to install it specifically for every user.

We do this by using the fact that the DLL is registered in the registry, so when the user right clicks a file for the first time, the DLL is loaded into explorer.exe's address space.
So we do the following:

- Ensure the process we are being loaded into is "explorer.exe", since we really don't want to do anything like this if we are being loaded into "regsvr32.exe"
- Once we know the process is the right one, we spawn a new thread to avoid freezing the UI while we run.
- In that thread, we start by getting the package - if it exists already, we stop, since nothing has to be done.
- If the package is missing, we register it and notifies the UI that we have made changes.

The cool thing about this, is that we only run the check when the user right click for the first time in their session, since that is the only time the DLL is loaded into explorer.exe - after that, it stays in memory for the rest of their session.

The only downside is that the very first time a user (that isn't the one who installed Notepad++) right clicks a file, the menu items will be missing, since we haven't had a check to register the items yet. (Since our code isn't running before then, we cannot do it before this).

This fixes notepad-plus-plus/notepad-plus-plus#13476