### PR TITLE
Changed logic to use an enum instead of a counter, making the code more stable and cleaner

### DIFF
--- a/BaseNppExplorerCommandHandler.cpp
+++ b/BaseNppExplorerCommandHandler.cpp
@@ -13,6 +13,7 @@ extern HMODULE g_module;
 BaseNppExplorerCommandHandler::BaseNppExplorerCommandHandler()
 {
     counter = make_unique<SharedCounter>();
+    state = make_unique<SharedState>();
 }
 
 const wstring BaseNppExplorerCommandHandler::GetNppExecutableFullPath()

--- a/BaseNppExplorerCommandHandler.h
+++ b/BaseNppExplorerCommandHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "ExplorerCommandBase.h"
 #include "SharedCounter.h"
+#include "SharedState.h"
 
 using namespace NppShell::Helpers;
 
@@ -24,5 +25,6 @@ namespace NppShell::CommandHandlers
 
     protected:
         unique_ptr<SharedCounter> counter;
+        unique_ptr<SharedState> state;
     };
 }

--- a/ClassicEditWithNppExplorerCommandHandler.cpp
+++ b/ClassicEditWithNppExplorerCommandHandler.cpp
@@ -1,17 +1,21 @@
 #include "pch.h"
 #include "ClassicEditWithNppExplorerCommandHandler.h"
 
+#include "SharedState.h"
+
 using namespace NppShell::CommandHandlers;
 
 const EXPCMDSTATE ClassicEditWithNppExplorerCommandHandler::State(IShellItemArray* psiItemArray)
 {
     UNREFERENCED_PARAMETER(psiItemArray);
 
-    int state = counter->GetValue();
+    // First we get the current state, before we clear it.
+    CounterState currentState = state->GetState();
+    state->SetState(NotSet);
 
-    if (state == 3 || state == 5)
+    // If it is set, it means the State function has been called in the Modern command handler last, which means we should hide this one.
+    if (currentState == CounterState::Set)
     {
-        // This is on Windows 11, with both the modern and classic being shows, so we hide this one.
         return ECS_HIDDEN;
     }
 

--- a/ModernEditWithNppExplorerCommandHandler.cpp
+++ b/ModernEditWithNppExplorerCommandHandler.cpp
@@ -1,11 +1,16 @@
 #include "pch.h"
 #include "ModernEditWithNppExplorerCommandHandler.h"
 
+#include "SharedState.h"
+
 using namespace NppShell::CommandHandlers;
+using namespace NppShell::Helpers;
 
 const EXPCMDSTATE ModernEditWithNppExplorerCommandHandler::State(IShellItemArray* psiItemArray)
 {
     UNREFERENCED_PARAMETER(psiItemArray);
+
+    state->SetState(Set);
 
     return ECS_ENABLED;
 }

--- a/NppShell.vcxproj
+++ b/NppShell.vcxproj
@@ -273,6 +273,7 @@
     <ClInclude Include="pch.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="SharedCounter.h" />
+    <ClInclude Include="SharedState.h" />
     <ClInclude Include="RegistryKey.h" />
     <ClInclude Include="SimpleFactory.h" />
     <ClInclude Include="ThreadUILanguageChanger.h" />
@@ -295,6 +296,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="SharedCounter.cpp" />
+    <ClCompile Include="SharedState.cpp" />
     <ClCompile Include="RegistryKey.cpp" />
     <ClCompile Include="ThreadUILanguageChanger.cpp" />
   </ItemGroup>

--- a/NppShell.vcxproj.filters
+++ b/NppShell.vcxproj.filters
@@ -22,6 +22,9 @@
     <Filter Include="Registry">
       <UniqueIdentifier>{2de5b87c-2f6d-4a04-bd61-1e1be9a91fdf}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Resources">
+      <UniqueIdentifier>{31c51ab1-0502-40df-b93e-2932b487656e}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Installer.h">
@@ -38,7 +41,6 @@
     <ClInclude Include="AclHelper.h">
       <Filter>Helpers</Filter>
     </ClInclude>
-    <ClInclude Include="SharedCounter.h" />
     <ClInclude Include="ExplorerCommandBase.h">
       <Filter>CommandHandlers\Base</Filter>
     </ClInclude>
@@ -54,8 +56,16 @@
     <ClInclude Include="RegistryKey.h">
       <Filter>Registry</Filter>
     </ClInclude>
-    <ClInclude Include="resource.h" />
     <ClInclude Include="ThreadUILanguageChanger.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
+    <ClInclude Include="SharedState.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Resources</Filter>
+    </ClInclude>
+    <ClInclude Include="SharedCounter.h">
       <Filter>Helpers</Filter>
     </ClInclude>
   </ItemGroup>
@@ -71,7 +81,6 @@
     <ClCompile Include="AclHelper.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
-    <ClCompile Include="SharedCounter.cpp" />
     <ClCompile Include="ExplorerCommandBase.cpp">
       <Filter>CommandHandlers\Base</Filter>
     </ClCompile>
@@ -90,6 +99,12 @@
     <ClCompile Include="ThreadUILanguageChanger.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
+    <ClCompile Include="SharedState.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
+    <ClCompile Include="SharedCounter.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -99,6 +114,8 @@
     <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
   </ItemGroup>
   <ItemGroup>
-    <ResourceCompile Include="NppShell.rc" />
+    <ResourceCompile Include="NppShell.rc">
+      <Filter>Resources</Filter>
+    </ResourceCompile>
   </ItemGroup>
 </Project>

--- a/SharedCounter.cpp
+++ b/SharedCounter.cpp
@@ -39,7 +39,8 @@ SharedCounter::SharedCounter()
     ReleaseMutex(hMutex);
 }
 
-SharedCounter::~SharedCounter() {
+SharedCounter::~SharedCounter()
+{
     // Decrement the shared counter
     WaitForSingleObject(hMutex, INFINITE);
     *pCounter -= 1;
@@ -53,6 +54,7 @@ SharedCounter::~SharedCounter() {
     CloseHandle(hFileMapping);
 }
 
-int SharedCounter::GetValue() const {
+int SharedCounter::GetValue() const
+{
     return localValue;
 }

--- a/SharedCounter.h
+++ b/SharedCounter.h
@@ -2,7 +2,8 @@
 
 namespace NppShell::Helpers
 {
-    class SharedCounter {
+    class SharedCounter
+    {
     public:
         SharedCounter();
         ~SharedCounter();

--- a/SharedState.cpp
+++ b/SharedState.cpp
@@ -1,0 +1,56 @@
+#include "pch.h"
+#include "SharedState.h"
+
+using namespace NppShell::Helpers;
+
+SharedState::SharedState()
+{
+    // Create or open the shared memory mapped file
+    hFileMapping = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, sizeof(int), L"Local\\BaseNppExplorerCommandHandlerSharedStateMemory");
+    if (hFileMapping == NULL)
+    {
+        MessageBox(NULL, L"Failed to create or open shared memory mapped file", L"SharedState", MB_OK | MB_ICONERROR);
+        return;
+    }
+
+    // Create a mutex to synchronize access to the shared memory
+    hMutex = CreateMutex(NULL, FALSE, L"Local\\BaseNppExplorerCommandHandlerSharedStateMutex");
+    if (hMutex == NULL)
+    {
+        MessageBox(NULL, L"Failed to create mutex", L"SharedState", MB_OK | MB_ICONERROR);
+        CloseHandle(hFileMapping);
+        return;
+    }
+
+    // Map the shared memory into the current process's address space
+    pState = (CounterState*)MapViewOfFile(hFileMapping, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(CounterState));
+    if (pState == NULL)
+    {
+        MessageBox(NULL, L"Failed to map shared memory", L"SharedState", MB_OK | MB_ICONERROR);
+        CloseHandle(hMutex);
+        CloseHandle(hFileMapping);
+        return;
+    }
+}
+
+SharedState::~SharedState()
+{
+    // Unmap the shared memory from the current process's address space
+    UnmapViewOfFile(pState);
+
+    // Close the mutex and the shared memory mapped file
+    CloseHandle(hMutex);
+    CloseHandle(hFileMapping);
+}
+
+CounterState SharedState::GetState() const
+{
+    return *pState;
+}
+
+void SharedState::SetState(CounterState state)
+{
+    WaitForSingleObject(hMutex, INFINITE);
+    *pState = state;
+    ReleaseMutex(hMutex);
+}

--- a/SharedState.h
+++ b/SharedState.h
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace NppShell::Helpers
+{
+    enum CounterState
+    {
+        NotSet,
+        Set
+    };
+
+    class SharedState
+    {
+    public:
+        SharedState();
+        ~SharedState();
+
+        CounterState GetState() const;
+        void SetState(CounterState state);
+
+    private:
+        HANDLE hFileMapping;
+        HANDLE hMutex;
+        CounterState* pState;
+    };
+}


### PR DESCRIPTION
This pull request refactors the SharedCounter to be a state instead of a counter.
Doing this results in the following changes:

- It works inside other programs, like [WinZIP](https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13476#issuecomment-1501607377)
- It is more stable, since it no longer uses a counter and checks for certain values (which is a bit hacky, and might break in the future).

Now it works by having a state variable that can be `NotSet` or `Set` - the modern handler changes the value to `Set`, and the classic handler reads the value, if it is `Set`, it hides itself. Then it resets it back to `NotSet`
This means that if the modern handler has been shown, in the current view, the classic one will hide itself, preventing double entries, but a lot more stable and elegant.

* This fixes notepad-plus-plus/notepad-plus-plus#13499
