### PR TITLE
Ensure dll has correct name when registering

### DIFF
--- a/Installer.h
+++ b/Installer.h
@@ -3,7 +3,7 @@
 
 namespace NppShell::Installer
 {
-    HRESULT RegisterOldContextMenu();
+    HRESULT RegisterOldContextMenu(const wstring& dllName);
     HRESULT UnregisterOldContextMenu();
 
     HRESULT RegisterSparsePackage();
@@ -13,6 +13,7 @@ namespace NppShell::Installer
     HRESULT Uninstall();
 
     void EnsureRegistrationOnCurrentUser();
+    void EnsureCorrectFileName(const wstring& targetFileName);
 }
 
 STDAPI CleanupDll();

--- a/PathHelper.cpp
+++ b/PathHelper.cpp
@@ -6,6 +6,15 @@ using namespace std::filesystem;
 
 extern HMODULE g_module;
 
+const wstring GetModuleName(HMODULE hModule)
+{
+    wchar_t pathBuffer[FILENAME_MAX] = { 0 };
+    GetModuleFileNameW(hModule, pathBuffer, FILENAME_MAX);
+    PathStripPathW(pathBuffer);
+
+    return wstring(pathBuffer);
+}
+
 const path GetModulePath()
 {
     wchar_t pathBuffer[MAX_PATH] = { 0 };
@@ -25,19 +34,15 @@ const wstring NppShell::Helpers::GetContextMenuPath()
     return modulePath.parent_path().wstring();
 }
 
-const wstring NppShell::Helpers::GetContextMenuFullName()
+const wstring NppShell::Helpers::GetContextMenuName()
 {
-    path modulePath = GetModulePath();
-    return modulePath.wstring();
+    return GetModuleName(g_module);
 }
 
 const wstring NppShell::Helpers::GetExecutingModuleName()
 {
-    wchar_t pathBuffer[FILENAME_MAX] = { 0 };
-    GetModuleFileNameW(NULL, pathBuffer, FILENAME_MAX);
-    PathStripPathW(pathBuffer);
+    wstring moduleName = GetModuleName(NULL);
 
-    wstring moduleName(pathBuffer);
     transform(moduleName.begin(), moduleName.end(), moduleName.begin(), towlower);
 
     return moduleName;

--- a/PathHelper.h
+++ b/PathHelper.h
@@ -7,6 +7,6 @@ namespace NppShell::Helpers
 {
     const wstring GetApplicationPath();
     const wstring GetContextMenuPath();
-    const wstring GetContextMenuFullName();
+    const wstring GetContextMenuName();
     const wstring GetExecutingModuleName();
 }


### PR DESCRIPTION
This fixes the installer race condition, where the rundll returns too early, causing the installer to fail to install the dll.

This just requires that the dll is installed using another name, then when it is registered, the existing dll (if there is one) is moved away and this one takes it's place.

This fixes notepad-plus-plus/notepad-plus-plus#13496, once the installer puts the DLL down using another name.