### PR TITLE
Fix opening multi-files on Notepad++ multi-instance mode regression

### DIFF
--- a/BaseNppExplorerCommandHandler.cpp
+++ b/BaseNppExplorerCommandHandler.cpp
@@ -124,27 +124,31 @@ IFACEMETHODIMP BaseNppExplorerCommandHandler::Invoke(IShellItemArray* psiItemArr
     RETURN_IF_FAILED(psiItemArray->GetCount(&count));
 
     IShellItem* psi = nullptr;
-    LPWSTR itemName;
-    wstring filePathsArg;
+    LPWSTR file2OpenPath;
+    
+    wstring appPath = L"\"";
+    appPath += GetNppExecutableFullPath().c_str();
+    appPath += L"\"";
+
+    wstring filePathsArg = appPath;
+    filePathsArg += L" ";
 
     for (DWORD i = 0; i < count; ++i)
     {
         psiItemArray->GetItemAt(i, &psi);
-        RETURN_IF_FAILED(psi->GetDisplayName(SIGDN_FILESYSPATH, &itemName));
-
-        const wstring commandLine = GetCommandLine(itemName);
-
-        // Cleanup itemName, since we are done with it.
-        if (itemName)
-        {
-            CoTaskMemFree(itemName);
-        }
-
+        RETURN_IF_FAILED(psi->GetDisplayName(SIGDN_FILESYSPATH, &file2OpenPath));
         // Release the IShellItem pointer, since we are done with it as well.
         psi->Release();
 
-        filePathsArg += commandLine;
-        filePathsArg += L" ";
+        filePathsArg += L"\"";
+        filePathsArg += file2OpenPath;
+        filePathsArg += L"\" ";
+
+        // Cleanup itemName, since we are done with it.
+        if (file2OpenPath)
+        {
+            CoTaskMemFree(file2OpenPath);
+        }
     }
 
     STARTUPINFO si;

--- a/BaseNppExplorerCommandHandler.cpp
+++ b/BaseNppExplorerCommandHandler.cpp
@@ -125,13 +125,13 @@ IFACEMETHODIMP BaseNppExplorerCommandHandler::Invoke(IShellItemArray* psiItemArr
 
     IShellItem* psi = nullptr;
     LPWSTR itemName;
+    wstring filePathsArg;
 
     for (DWORD i = 0; i < count; ++i)
     {
         psiItemArray->GetItemAt(i, &psi);
         RETURN_IF_FAILED(psi->GetDisplayName(SIGDN_FILESYSPATH, &itemName));
 
-        const wstring applicationName = GetNppExecutableFullPath();
         const wstring commandLine = GetCommandLine(itemName);
 
         // Cleanup itemName, since we are done with it.
@@ -143,24 +143,24 @@ IFACEMETHODIMP BaseNppExplorerCommandHandler::Invoke(IShellItemArray* psiItemArr
         // Release the IShellItem pointer, since we are done with it as well.
         psi->Release();
 
-        STARTUPINFO si;
-        PROCESS_INFORMATION pi;
-
-        ZeroMemory(&si, sizeof(si));
-        si.cb = sizeof(si);
-        ZeroMemory(&pi, sizeof(pi));
-
-        wchar_t* application = (LPWSTR)applicationName.c_str();
-        wchar_t* command = (LPWSTR)commandLine.c_str();
-
-        if (!CreateProcessW(application, command, nullptr, nullptr, false, CREATE_NEW_PROCESS_GROUP, nullptr, nullptr, &si, &pi))
-        {
-            return S_OK;
-        }
-
-        CloseHandle(pi.hProcess);
-        CloseHandle(pi.hThread);
+        filePathsArg += commandLine;
+        filePathsArg += L" ";
     }
+
+    STARTUPINFO si;
+    PROCESS_INFORMATION pi;
+
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+    ZeroMemory(&pi, sizeof(pi));
+
+    if (!CreateProcessW(GetNppExecutableFullPath().c_str(), (LPWSTR)filePathsArg.c_str(), nullptr, nullptr, false, CREATE_NEW_PROCESS_GROUP, nullptr, nullptr, &si, &pi))
+    {
+        return S_OK;
+    }
+
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
 
     return S_OK;
 }


### PR DESCRIPTION
Before this commit, if N files are selected, NppShell calls Notepad++ N times (each time for per file).
In this commit, we call Notepad++ only once, instead of calling it N times.

Fix #36, fix https://github.com/notepad-plus-plus/notepad-plus-plus/issues/13778