### PR TITLE
Added logging

### DIFF
--- a/ClassicEditWithNppExplorerCommandHandler.cpp
+++ b/ClassicEditWithNppExplorerCommandHandler.cpp
@@ -1,9 +1,23 @@
 #include "pch.h"
 #include "ClassicEditWithNppExplorerCommandHandler.h"
 
+#include "LoggingHelper.h"
 #include "SharedState.h"
 
 using namespace NppShell::CommandHandlers;
+using namespace NppShell::Helpers;
+
+extern LoggingHelper g_loggingHelper;
+
+ClassicEditWithNppExplorerCommandHandler::ClassicEditWithNppExplorerCommandHandler()
+{
+    g_loggingHelper.LogMessage(L"ClassicEditWithNppExplorerCommandHandler::ctor", L"Creating object");
+}
+
+ClassicEditWithNppExplorerCommandHandler::~ClassicEditWithNppExplorerCommandHandler()
+{
+    g_loggingHelper.LogMessage(L"ClassicEditWithNppExplorerCommandHandler::~tor", L"Destroying object");
+}
 
 const EXPCMDSTATE ClassicEditWithNppExplorerCommandHandler::State(IShellItemArray* psiItemArray)
 {
@@ -12,6 +26,8 @@ const EXPCMDSTATE ClassicEditWithNppExplorerCommandHandler::State(IShellItemArra
     // First we get the current state, before we clear it.
     CounterState currentState = state->GetState();
     state->SetState(NotSet);
+
+    g_loggingHelper.LogMessage(L"ClassicEditWithNppExplorerCommandHandler::State", L"Current state: " + std::to_wstring(currentState));
 
     // If it is set, it means the State function has been called in the Modern command handler last, which means we should hide this one.
     if (currentState == CounterState::Set)

--- a/ClassicEditWithNppExplorerCommandHandler.h
+++ b/ClassicEditWithNppExplorerCommandHandler.h
@@ -12,6 +12,9 @@ namespace NppShell::CommandHandlers
 #endif
     {
     public:
+        ClassicEditWithNppExplorerCommandHandler();
+        ~ClassicEditWithNppExplorerCommandHandler();
+
         const EXPCMDSTATE State(IShellItemArray* psiItemArray);
     };
 }

--- a/LoggingHelper.cpp
+++ b/LoggingHelper.cpp
@@ -15,7 +15,7 @@ LoggingHelper::LoggingHelper()
     }
 
     const wstring logFileFolder = CreateAppDataFolder();
-    logFilePath = logFileFolder + L"\\NppShell.txt";
+    logFilePath = logFileFolder + L"\\NppShell.log";
 }
 
 void LoggingHelper::LogMessage(const wstring& source, const wstring& message)

--- a/LoggingHelper.cpp
+++ b/LoggingHelper.cpp
@@ -1,0 +1,143 @@
+#include "pch.h"
+#include "LoggingHelper.h"
+
+#include <fstream>
+
+using namespace NppShell::Helpers;
+
+LoggingHelper::LoggingHelper()
+{
+    appDataLoggingEnabled = IsAppDataLoggingEnabled();
+
+    if (!appDataLoggingEnabled)
+    {
+        return;
+    }
+
+    const wstring logFileFolder = CreateAppDataFolder();
+    logFilePath = logFileFolder + L"\\NppShell.txt";
+}
+
+void LoggingHelper::LogMessage(const wstring& source, const wstring& message)
+{
+    if (!appDataLoggingEnabled)
+    {
+        return;
+    }
+
+    wofstream file(logFilePath, ios_base::app);
+    if (file.is_open())
+    {
+        file << GetTimestamp();
+        file << L" - ";
+        file << source;
+        file << L": ";
+        file << message;
+        file << endl;
+        file.close();
+    }
+}
+
+wstring LoggingHelper::GetRoamingAppDataFolderPath()
+{
+    // Initialize COM
+    CoInitialize(NULL);
+
+    // Create an instance of the KnownFolderManager interface
+    IKnownFolderManager* pManager;
+    HRESULT hr = CoCreateInstance(CLSID_KnownFolderManager, NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pManager));
+
+    if (FAILED(hr))
+    {
+        // Handle error
+        return L"";
+    }
+
+    // Get the Roaming App Data folder
+    IKnownFolder* pFolder;
+    hr = pManager->GetFolder(FOLDERID_RoamingAppData, &pFolder);
+    if (FAILED(hr))
+    {
+        // Handle error
+        pManager->Release();
+        return L"";
+    }
+
+    // Get the path to the Roaming App Data folder
+    PWSTR pszPath = nullptr;
+    hr = pFolder->GetPath(KF_FLAG_DEFAULT, &pszPath);
+    if (FAILED(hr))
+    {
+        // Handle error
+        pFolder->Release();
+        pManager->Release();
+
+        return L"";
+    }
+
+    // Convert the path to a wstring
+    wstring path(pszPath);
+
+    // Free the allocated memory
+    CoTaskMemFree(pszPath);
+
+    // Release interfaces
+    pFolder->Release();
+    pManager->Release();
+
+    // Uninitialize COM
+    CoUninitialize();
+
+    // Return the path to the Roaming App Data folder
+    return path;
+}
+
+wstring LoggingHelper::CreateAppDataFolder()
+{
+    wstring folderPath = GetRoamingAppDataFolderPath() + L"\\NppShell";
+
+    if (!CreateDirectoryW(folderPath.c_str(), NULL) && GetLastError() != ERROR_ALREADY_EXISTS)
+    {
+        throw runtime_error("Failed to create folder");
+    }
+
+    return folderPath;
+}
+
+wstring LoggingHelper::GetTimestamp()
+{
+    SYSTEMTIME st;
+    GetLocalTime(&st);
+
+    wchar_t buffer[25];
+    swprintf_s(buffer, L"%04d-%02d-%02d %02d:%02d:%02d", st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
+
+    return wstring(buffer);
+}
+
+bool LoggingHelper::IsAppDataLoggingEnabled()
+{
+    const wstring environmentVariableName = L"NPPSHELL_LOGGING_ENABLED";
+
+    // Get the size of the buffer required to hold the environment variable value
+    DWORD size = GetEnvironmentVariableW(environmentVariableName.c_str(), nullptr, 0);
+    if (size == 0)
+    {
+        // The specified environment variable was not found
+        return false;
+    }
+
+    // Allocate a buffer to hold the environment variable value
+    wstring buffer(size, L'\0');
+
+    // Retrieve the environment variable value
+    DWORD result = GetEnvironmentVariableW(environmentVariableName.c_str(), buffer.data(), size);
+    if (result == 0 || result > size)
+    {
+        // An error occurred while retrieving the environment variable value
+        return false;
+    }
+
+    // Return if the value is set to true
+    return wstring(buffer.data()) == L"true";
+}

--- a/LoggingHelper.h
+++ b/LoggingHelper.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace NppShell::Helpers
+{
+    class LoggingHelper
+    {
+    public:
+        LoggingHelper();
+        void LogMessage(const wstring& source, const wstring& message);
+
+    private:
+        wstring GetRoamingAppDataFolderPath();
+        wstring CreateAppDataFolder();
+        wstring GetTimestamp();
+        bool IsAppDataLoggingEnabled();
+
+        bool appDataLoggingEnabled;
+        wstring logFilePath;
+    };
+}

--- a/ModernEditWithNppExplorerCommandHandler.cpp
+++ b/ModernEditWithNppExplorerCommandHandler.cpp
@@ -2,15 +2,30 @@
 #include "ModernEditWithNppExplorerCommandHandler.h"
 
 #include "SharedState.h"
+#include "LoggingHelper.h"
 
 using namespace NppShell::CommandHandlers;
 using namespace NppShell::Helpers;
+
+extern LoggingHelper g_loggingHelper;
+
+ModernEditWithNppExplorerCommandHandler::ModernEditWithNppExplorerCommandHandler()
+{
+    g_loggingHelper.LogMessage(L"ModernEditWithNppExplorerCommandHandler::ctor", L"Creating object");
+}
+
+ModernEditWithNppExplorerCommandHandler::~ModernEditWithNppExplorerCommandHandler()
+{
+    g_loggingHelper.LogMessage(L"ModernEditWithNppExplorerCommandHandler::~tor", L"Destroying object");
+}
 
 const EXPCMDSTATE ModernEditWithNppExplorerCommandHandler::State(IShellItemArray* psiItemArray)
 {
     UNREFERENCED_PARAMETER(psiItemArray);
 
     state->SetState(Set);
+
+    g_loggingHelper.LogMessage(L"ModernEditWithNppExplorerCommandHandler::State", L"Current state: " + std::to_wstring(state->GetState()));
 
     return ECS_ENABLED;
 }

--- a/ModernEditWithNppExplorerCommandHandler.h
+++ b/ModernEditWithNppExplorerCommandHandler.h
@@ -8,6 +8,9 @@ namespace NppShell::CommandHandlers
     class __declspec(uuid("E6950302-61F0-4FEB-97DB-855E30D4A991")) ModernEditWithNppExplorerCommandHandler : public BaseNppExplorerCommandHandler
     {
     public:
+        ModernEditWithNppExplorerCommandHandler();
+        ~ModernEditWithNppExplorerCommandHandler();
+
         const EXPCMDSTATE State(IShellItemArray* psiItemArray);
     };
 }

--- a/NppShell.vcxproj
+++ b/NppShell.vcxproj
@@ -267,6 +267,7 @@
     <ClInclude Include="ClassicEditWithNppExplorerCommandHandler.h" />
     <ClInclude Include="ExplorerCommandBase.h" />
     <ClInclude Include="framework.h" />
+    <ClInclude Include="LoggingHelper.h" />
     <ClInclude Include="ModernEditWithNppExplorerCommandHandler.h" />
     <ClInclude Include="PathHelper.h" />
     <ClInclude Include="Installer.h" />
@@ -284,6 +285,7 @@
     <ClCompile Include="ClassicEditWithNppExplorerCommandHandler.cpp" />
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="ExplorerCommandBase.cpp" />
+    <ClCompile Include="LoggingHelper.cpp" />
     <ClCompile Include="ModernEditWithNppExplorerCommandHandler.cpp" />
     <ClCompile Include="PathHelper.cpp" />
     <ClCompile Include="Installer.cpp" />

--- a/NppShell.vcxproj.filters
+++ b/NppShell.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClInclude Include="SharedCounter.h">
       <Filter>Helpers</Filter>
     </ClInclude>
+    <ClInclude Include="LoggingHelper.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Installer.cpp">
@@ -79,6 +82,9 @@
       <Filter>Helpers</Filter>
     </ClCompile>
     <ClCompile Include="AclHelper.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
+    <ClCompile Include="LoggingHelper.cpp">
       <Filter>Helpers</Filter>
     </ClCompile>
     <ClCompile Include="ExplorerCommandBase.cpp">

--- a/RegistryKey.cpp
+++ b/RegistryKey.cpp
@@ -1,13 +1,18 @@
 #include "pch.h"
 #include "RegistryKey.h"
+#include "LoggingHelper.h"
 
 using namespace NppShell::Registry;
+using namespace NppShell::Helpers;
+
+extern LoggingHelper g_loggingHelper;
 
 RegistryKey::RegistryKey(HKEY hKey, const wstring& subKey, REGSAM access, bool createIfMissing)
     : m_hKey(nullptr), m_regsam(access), m_originalHKey(hKey), m_originalSubKey(subKey)
 {
     if (RegOpenKeyExW(hKey, subKey.data(), 0, access, &m_hKey) == ERROR_SUCCESS)
     {
+        g_loggingHelper.LogMessage(L"RegistryKey::ctor", L"Opened sub key: " + subKey);
         return;
     }
 
@@ -20,7 +25,12 @@ RegistryKey::RegistryKey(HKEY hKey, const wstring& subKey, REGSAM access, bool c
 
     if (RegCreateKeyExW(hKey, subKey.data(), 0, nullptr, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, nullptr, &m_hKey, &disposition) != ERROR_SUCCESS)
     {
+        g_loggingHelper.LogMessage(L"RegistryKey::ctor", L"Failed to create sub key: " + subKey);
         throw runtime_error("Failed to create registry key.");
+    }
+    else
+    {
+        g_loggingHelper.LogMessage(L"RegistryKey::ctor", L"Created sub key: " + subKey);
     }
 }
 
@@ -102,6 +112,7 @@ DWORD RegistryKey::GetDwordValue(const wstring& valueName)
 
     if (RegGetValueW(m_hKey, nullptr, valueName.empty() ? NULL : valueName.data(), RRF_RT_REG_DWORD, nullptr, &value, &dataSize) != ERROR_SUCCESS)
     {
+        g_loggingHelper.LogMessage(L"RegistryKey::GetDwordValue", L"Failed to get DWORD value: " + valueName);
         throw runtime_error("Failed to get registry value.");
     }
 
@@ -119,6 +130,7 @@ wstring RegistryKey::GetStringValue(const wstring& valueName)
 
     if (RegGetValueW(m_hKey, nullptr, valueName.empty() ? NULL : valueName.data(), RRF_RT_REG_SZ, nullptr, nullptr, &dataSize) != ERROR_SUCCESS)
     {
+        g_loggingHelper.LogMessage(L"RegistryKey::GetStringValue", L"Failed to get REG_SZ value: " + valueName);
         throw runtime_error("Failed to get registry value size.");
     }
 
@@ -126,6 +138,7 @@ wstring RegistryKey::GetStringValue(const wstring& valueName)
 
     if (RegGetValueW(m_hKey, nullptr, valueName.empty() ? NULL : valueName.data(), RRF_RT_REG_SZ, nullptr, bit_cast<BYTE*>(value.data()), &dataSize) != ERROR_SUCCESS)
     {
+        g_loggingHelper.LogMessage(L"RegistryKey::GetStringValue", L"Failed to get REG_SZ value: " + valueName);
         throw runtime_error("Failed to get registry value.");
     }
 
@@ -141,8 +154,12 @@ void RegistryKey::SetDwordValue(const wstring& valueName, DWORD value)
 
     if (RegSetValueExW(m_hKey, valueName.empty() ? NULL : valueName.data(), 0, REG_DWORD, bit_cast<const BYTE*>(&value), sizeof(DWORD)) != ERROR_SUCCESS)
     {
+        g_loggingHelper.LogMessage(L"RegistryKey::SetDwordValue", L"Failed to set DWORD value: " + valueName);
         throw runtime_error("Failed to set registry value.");
     }
+
+    wstring valueNameLog = valueName.empty() ? L"(default)" : valueName.data();
+    g_loggingHelper.LogMessage(L"RegistryKey::SetDwordValue", L"Setting DWORD name: " + valueNameLog + L" to: " + to_wstring(value));
 }
 
 void RegistryKey::SetStringValue(const wstring& valueName, const wstring& value)
@@ -154,8 +171,12 @@ void RegistryKey::SetStringValue(const wstring& valueName, const wstring& value)
 
     if (RegSetValueExW(m_hKey, valueName.empty() ? NULL : valueName.data(), 0, REG_SZ, bit_cast<const BYTE*>(value.data()), static_cast<DWORD>((value.length() + 1) * sizeof(wchar_t))) != ERROR_SUCCESS)
     {
+        g_loggingHelper.LogMessage(L"RegistryKey::SetStringValue", L"Failed to set REG_SZ value: " + valueName);
         throw runtime_error("Failed to set registry value.");
     }
+
+    wstring valueNameLog = valueName.empty() ? L"(default)" : valueName.data();
+    g_loggingHelper.LogMessage(L"RegistryKey::SetStringValue", L"Setting REG_SZ name: " + valueNameLog + L" to: \"" + value + L"\"");
 }
 
 void RegistryKey::DeleteKey()
@@ -167,8 +188,11 @@ void RegistryKey::DeleteKey()
     
     if (RegDeleteTreeW(m_originalHKey, m_originalSubKey.data()) != ERROR_SUCCESS)
     {
+        g_loggingHelper.LogMessage(L"RegistryKey::DeleteKey", L"Failed to delete subkey: " + m_originalSubKey);
         throw runtime_error("Failed to delete registry key.");
     }
+
+    g_loggingHelper.LogMessage(L"RegistryKey::DeleteKey", L"Deleted subkey: " + m_originalSubKey);
 
     m_hKey = nullptr;
     m_originalHKey = nullptr;

--- a/SharedCounter.cpp
+++ b/SharedCounter.cpp
@@ -1,7 +1,10 @@
 #include "pch.h"
 #include "SharedCounter.h"
+#include "LoggingHelper.h"
 
 using namespace NppShell::Helpers;
+
+extern LoggingHelper g_loggingHelper;
 
 SharedCounter::SharedCounter()
 {
@@ -9,7 +12,7 @@ SharedCounter::SharedCounter()
     hFileMapping = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, sizeof(int), L"Local\\BaseNppExplorerCommandHandlerSharedMemory");
     if (hFileMapping == NULL)
     {
-        MessageBox(NULL, L"Failed to create or open shared memory mapped file", L"SharedCounter", MB_OK | MB_ICONERROR);
+        g_loggingHelper.LogMessage(L"SharedCounter::ctor", L"Failed to create or open shared memory mapped file");
         return;
     }
 
@@ -17,7 +20,7 @@ SharedCounter::SharedCounter()
     hMutex = CreateMutex(NULL, FALSE, L"Local\\BaseNppExplorerCommandHandlerSharedMutex");
     if (hMutex == NULL)
     {
-        MessageBox(NULL, L"Failed to create mutex", L"SharedCounter", MB_OK | MB_ICONERROR);
+        g_loggingHelper.LogMessage(L"SharedCounter::ctor", L"Failed to create mutex");
         CloseHandle(hFileMapping);
         return;
     }
@@ -26,7 +29,7 @@ SharedCounter::SharedCounter()
     pCounter = (int*)MapViewOfFile(hFileMapping, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(int));
     if (pCounter == NULL)
     {
-        MessageBox(NULL, L"Failed to map shared memory", L"SharedCounter", MB_OK | MB_ICONERROR);
+        g_loggingHelper.LogMessage(L"SharedCounter::ctor", L"Failed to map shared memory");
         CloseHandle(hMutex);
         CloseHandle(hFileMapping);
         return;

--- a/SharedState.cpp
+++ b/SharedState.cpp
@@ -1,7 +1,10 @@
 #include "pch.h"
 #include "SharedState.h"
+#include "LoggingHelper.h"
 
 using namespace NppShell::Helpers;
+
+extern LoggingHelper g_loggingHelper;
 
 SharedState::SharedState()
 {
@@ -9,7 +12,7 @@ SharedState::SharedState()
     hFileMapping = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, sizeof(int), L"Local\\BaseNppExplorerCommandHandlerSharedStateMemory");
     if (hFileMapping == NULL)
     {
-        MessageBox(NULL, L"Failed to create or open shared memory mapped file", L"SharedState", MB_OK | MB_ICONERROR);
+        g_loggingHelper.LogMessage(L"SharedState::ctor", L"Failed to create or open shared memory mapped file");
         return;
     }
 
@@ -17,7 +20,7 @@ SharedState::SharedState()
     hMutex = CreateMutex(NULL, FALSE, L"Local\\BaseNppExplorerCommandHandlerSharedStateMutex");
     if (hMutex == NULL)
     {
-        MessageBox(NULL, L"Failed to create mutex", L"SharedState", MB_OK | MB_ICONERROR);
+        g_loggingHelper.LogMessage(L"SharedState::ctor", L"Failed to create mutex");
         CloseHandle(hFileMapping);
         return;
     }
@@ -52,5 +55,6 @@ void SharedState::SetState(CounterState state)
 {
     WaitForSingleObject(hMutex, INFINITE);
     *pState = state;
+    g_loggingHelper.LogMessage(L"SharedState::SetState", L"Set shared state to: " + to_wstring(state));
     ReleaseMutex(hMutex);
 }

--- a/ThreadUILanguageChanger.cpp
+++ b/ThreadUILanguageChanger.cpp
@@ -1,7 +1,10 @@
 #include "pch.h"
 #include "ThreadUILanguageChanger.h"
+#include "LoggingHelper.h"
 
 using namespace NppShell::Helpers;
+
+extern LoggingHelper g_loggingHelper;
 
 ThreadUILanguageChanger::ThreadUILanguageChanger(const wstring& languageTag)
 {
@@ -10,12 +13,17 @@ ThreadUILanguageChanger::ThreadUILanguageChanger(const wstring& languageTag)
 
     // Set the new thread UI language setting
     SetThreadLanguage(languageTag);
+
+    g_loggingHelper.LogMessage(L"ThreadUILanguageChanger::ctor", L"Original language: " + m_originalLanguageTag);
+    g_loggingHelper.LogMessage(L"ThreadUILanguageChanger::ctor", L"New language: " + languageTag);
 }
 
 ThreadUILanguageChanger::~ThreadUILanguageChanger()
 {
     // Restore the original thread UI language setting
     SetThreadLanguage(m_originalLanguageTag);
+
+    g_loggingHelper.LogMessage(L"ThreadUILanguageChanger::~tor", L"Original language: " + m_originalLanguageTag);
 }
 
 wstring ThreadUILanguageChanger::GetThreadLanguage()

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -4,11 +4,14 @@
 #include "SimpleFactory.h"
 #include "ClassicEditWithNppExplorerCommandHandler.h"
 #include "ModernEditWithNppExplorerCommandHandler.h"
+#include "LoggingHelper.h"
 
 using namespace NppShell::CommandHandlers;
 using namespace NppShell::Factories;
+using namespace NppShell::Helpers;
 
 HMODULE g_module;
+LoggingHelper g_loggingHelper;
 
 BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
 {


### PR DESCRIPTION
This enables logging in the context menu handlers.
To enable logging, set the environment variable `NPPSHELL_LOGGING_ENABLED` to `true` and restart explorer.
To disable logging, set it to something else (or remove it) and restart explorer.