### PR TITLE
fix Win11 Explorer crash in SafeMode due to NppShell unhandled exception

### DIFF
--- a/Installer.cpp
+++ b/Installer.cpp
@@ -208,6 +208,9 @@ Package GetSparsePackage()
 
 HRESULT NppShell::Installer::RegisterSparsePackage()
 {
+    if (::GetSystemMetrics(SM_CLEANBOOT) > 0)
+        return S_FALSE; // Otherwise we will get an unhandled exception later due to HRESULT 0x8007043c (ERROR_NOT_SAFEBOOT_SERVICE).
+
     PackageManager packageManager;
     AddPackageOptions options;
 
@@ -232,6 +235,9 @@ HRESULT NppShell::Installer::RegisterSparsePackage()
 
 HRESULT NppShell::Installer::UnregisterSparsePackage()
 {
+    if (::GetSystemMetrics(SM_CLEANBOOT) > 0)
+        return S_FALSE; // Only to speed up things a bit here. (code in the following GetSparsePackage() is safe against the ERROR_NOT_SAFEBOOT_SERVICE)
+
     PackageManager packageManager;
     IIterable<Package> packages;
 
@@ -291,6 +297,9 @@ HRESULT NppShell::Installer::UnregisterOldContextMenu()
 
 void ReRegisterSparsePackage()
 {
+    if (::GetSystemMetrics(SM_CLEANBOOT) > 0)
+        return; // Sparse package reg/unreg cannot be done in the Windows OS SafeMode.
+
     winrt::init_apartment();
 
     // Since we are on Windows 11, we unregister the sparse package as well.


### PR DESCRIPTION
Fixes #45 .

Sparse packages handling does not work in the Windows OS SafeMode.
But the NppShell classic-menu functionality remains fully functional there (even with this patch).