### PR TITLE
update outdated CI actions 

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -15,10 +15,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1
+      uses: microsoft/setup-msbuild@v2
 
     - name: Setup NuGet.exe
-      uses: nuget/setup-nuget@v1
+      uses: nuget/setup-nuget@v2
 
     - name: Restore
       working-directory: .


### PR DESCRIPTION
to avoid warnings:

The following actions uses Node.js version which is deprecated and will be forced to run on node20: microsoft/setup-msbuild@v1, nuget/setup-nuget@v1. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

see e.g. https://github.com/notepad-plus-plus/nppShell/actions/runs/9810120608